### PR TITLE
chore(CI): extended doc artefact to 1 week

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -45,4 +45,4 @@ jobs:
           path: |
             ${{github.workspace}}/build/html
             ${{github.workspace}}/build/doxygen-warnings.log
-          retention-days: 1
+          retention-days: 15


### PR DESCRIPTION
Since the artifact is now used by the website, keeping it alive for only a day is not enought. Two week should be more confortable to work with
