### PR TITLE
chore(AABB): rename MeshBoundingBox

### DIFF
--- a/libgraphics/include/pivot/graphics/AssetStorage.hxx
+++ b/libgraphics/include/pivot/graphics/AssetStorage.hxx
@@ -4,11 +4,11 @@
 #include "pivot/graphics/DescriptorAllocator/DescriptorBuilder.hxx"
 #include "pivot/graphics/VulkanBase.hxx"
 #include "pivot/graphics/abstract/AImmediateCommand.hxx"
+#include "pivot/graphics/types/AABB.hxx"
 #include "pivot/graphics/types/AllocatedBuffer.hxx"
 #include "pivot/graphics/types/AllocatedImage.hxx"
 #include "pivot/graphics/types/IndexedStorage.hxx"
 #include "pivot/graphics/types/Material.hxx"
-#include "pivot/graphics/types/MeshBoundingBox.hxx"
 #include "pivot/graphics/types/Vertex.hxx"
 #include "pivot/graphics/types/common.hxx"
 
@@ -165,7 +165,7 @@ public:
     ///
     /// This is the corresponding code in glsl code
     /// @code{.glsl}
-    /// struct BoundingBox {
+    /// struct AABB {
     ///     vec3 low;
     ///     vec3 high;
     /// };
@@ -180,9 +180,9 @@ public:
     ///     int emissiveTexture;
     /// };
     ///
-    /// layout(set = 0, binding = 0) readonly buffer ObjectBoundingBoxes{
-    ///     BoundingBox boundingBoxes[];
-    /// } objectBoundingBoxes;
+    /// layout(set = 0, binding = 0) readonly buffer ObjectAABB{
+    ///     AABB boundingBoxes[];
+    /// } objectAABB;
     ///
     /// layout (std140, set = 0, binding = 1) readonly buffer ObjectMaterials {
     ///     Material materials[];
@@ -236,7 +236,7 @@ private:
 
     // Push to gpu
     void pushModelsOnGPU();
-    void pushBoundingBoxesOnGPU();
+    void pushAABBOnGPU();
     void pushTexturesOnGPU();
     void pushMaterialOnGPU();
 
@@ -253,7 +253,7 @@ private:
     std::unordered_map<std::string, Prefab> prefabStorage;
 
     // Buffers
-    IndexedStorage<std::string, gpu_object::MeshBoundingBox> meshBoundingBoxStorage;
+    IndexedStorage<std::string, gpu_object::AABB> meshAABBStorage;
     IndexedStorage<std::string, Texture> textureStorage;
     IndexedStorage<std::string, gpu_object::Material> materialStorage;
 
@@ -267,7 +267,7 @@ private:
     vk::DescriptorSet descriptorSet;
     AllocatedBuffer<Vertex> vertexBuffer;
     AllocatedBuffer<std::uint32_t> indicesBuffer;
-    AllocatedBuffer<gpu_object::MeshBoundingBox> boundingboxBuffer;
+    AllocatedBuffer<gpu_object::AABB> AABBBuffer;
     AllocatedBuffer<gpu_object::Material> materialBuffer;
 };
 
@@ -314,9 +314,9 @@ inline const AssetStorage::Mesh &AssetStorage::get(const std::string &p) const
 // Get Index of asset in the buffers
 template <>
 /// @copydoc AssetStorage::get
-inline std::int32_t AssetStorage::getIndex<gpu_object::MeshBoundingBox>(const std::string &i) const
+inline std::int32_t AssetStorage::getIndex<gpu_object::AABB>(const std::string &i) const
 {
-    return meshBoundingBoxStorage.getIndex(i);
+    return meshAABBStorage.getIndex(i);
 }
 
 template <>

--- a/libgraphics/include/pivot/graphics/culling.hxx
+++ b/libgraphics/include/pivot/graphics/culling.hxx
@@ -5,6 +5,5 @@
 
 namespace pivot::graphics::culling
 {
-bool should_object_be_rendered(const Transform &transform, const gpu_object::MeshBoundingBox &box,
-                               const CameraData &camera);
+bool should_object_be_rendered(const Transform &transform, const gpu_object::AABB &box, const CameraData &camera);
 }

--- a/libgraphics/include/pivot/graphics/types/AABB.hxx
+++ b/libgraphics/include/pivot/graphics/types/AABB.hxx
@@ -9,25 +9,25 @@
 
 namespace pivot::graphics::gpu_object
 {
-/// @struct MeshBoundingBox
+/// @struct AABB
 ///
 /// @brief Represents the cubic bounding box of a mesh
-struct MeshBoundingBox {
-    MeshBoundingBox() = delete;
+struct AABB {
+    AABB() = delete;
 
     /// Construct a Bounding box using a complete mesh
-    explicit constexpr MeshBoundingBox(const std::span<const Vertex> &mesh)
+    explicit constexpr AABB(const std::span<const Vertex> &mesh)
     {
-        if (mesh.empty()) throw std::runtime_error("Can't build a MeshBoundingBox without Vertices");
+        if (mesh.empty()) throw std::runtime_error("Can't build a AABB without Vertices");
         low = mesh.front().pos;
         high = low;
         for (const auto &point: mesh) addPoint(point.pos);
     };
 
     /// New bounding box for a model with only one point
-    explicit constexpr MeshBoundingBox(glm::vec3 initialPoint): low(initialPoint), high(initialPoint){};
+    explicit constexpr AABB(glm::vec3 initialPoint): low(initialPoint), high(initialPoint){};
     /// New bounding box with explicitely set low and high point
-    explicit constexpr MeshBoundingBox(glm::vec3 low, glm::vec3 high): low(low), high(high){};
+    explicit constexpr AABB(glm::vec3 low, glm::vec3 high): low(low), high(high){};
 
     /// Lowest point of the bouding box
     alignas(16) glm::vec3 low;
@@ -62,7 +62,7 @@ struct MeshBoundingBox {
     }
 };
 
-static_assert(sizeof(MeshBoundingBox) % 4 == 0);
-static_assert(sizeof(MeshBoundingBox) == sizeof(float) * 4 * 2);
+static_assert(sizeof(AABB) % 4 == 0);
+static_assert(sizeof(AABB) == sizeof(float) * 4 * 2);
 
 }    // namespace pivot::graphics::gpu_object

--- a/libgraphics/shaders/culling.comp
+++ b/libgraphics/shaders/culling.comp
@@ -24,14 +24,14 @@ layout (set = 1, binding = 1) buffer DrawIndexedIndirectBuffer {
     DrawIndexedIndirect drawIndexedIndirect[];
 } drawIndexedIndirectBuffer;
 
-struct BoundingBox {
+struct AABB {
     vec3 low;
     vec3 high;
 };
 
-layout (set = 0, binding = 0) readonly buffer ObjectBoundingBoxes {
-    BoundingBox boundingBoxes[];
-} objectBoundingBoxes;
+layout (set = 0, binding = 0) readonly buffer ObjectAABB {
+    AABB boundingBoxes[];
+} objectAABB;
 
 layout (push_constant) uniform readonly constants {
 	mat4 viewproj;
@@ -47,7 +47,7 @@ const vec4 planes[6] = vec4[](
     vec4(0, 0, 1, 0)
 );
 
-void generateAllBoundingBoxPoints(in BoundingBox box, inout vec3 points[8]) {
+void generateAllAABBPoints(in AABB box, inout vec3 points[8]) {
     points[0] = box.low;
     points[1] = vec3(box.high.x, box.low.yz);
     points[2] = vec3(box.low.x, box.high.y, box.low.z);
@@ -63,12 +63,12 @@ void main() {
 
     if (gID < cameraData.drawCount) {
         uint boundingBoxIndex = objectBuffer.objects[gID].boundingBoxIndex;
-        BoundingBox boundingBox = objectBoundingBoxes.boundingBoxes[boundingBoxIndex];
+        AABB boundingBox = objectAABB.boundingBoxes[boundingBoxIndex];
 
         mat4 vpm = cameraData.viewproj * objectBuffer.objects[gID].modelMatrix;
         vec4 boundingBoxProjection[8];
         vec3 points[8];
-        generateAllBoundingBoxPoints(boundingBox, points);
+        generateAllAABBPoints(boundingBox, points);
         for (uint i = 0; i < 8; i++) {
             boundingBoxProjection[i] = vpm * vec4(points[i], 1.0);
         }

--- a/libgraphics/source/AssetsStorage/AssetStorage_init.cxx
+++ b/libgraphics/source/AssetsStorage/AssetStorage_init.cxx
@@ -44,7 +44,7 @@ void AssetStorage::createDescriptorSet(DescriptorBuilder &builder)
     std::ranges::transform(textureStorage.getStorage(), std::back_inserter(imagesInfos),
                            [this](const auto &i) { return i.getImageInfo(textureSampler); });
     builder
-        .bindBuffer(0, boundingboxBuffer.getBufferInfo(), vk::DescriptorType::eStorageBuffer,
+        .bindBuffer(0, AABBBuffer.getBufferInfo(), vk::DescriptorType::eStorageBuffer,
                     vk::ShaderStageFlagBits::eCompute)
         .bindBuffer(1, materialBuffer.getBufferInfo(), vk::DescriptorType::eStorageBuffer,
                     vk::ShaderStageFlagBits::eFragment)

--- a/libgraphics/source/culling.cxx
+++ b/libgraphics/source/culling.cxx
@@ -12,8 +12,7 @@ const static std::array<glm::vec4, 6> planes = {{
     {0, 0, 1, 0},
 }};
 
-bool should_object_be_rendered(const Transform &transform, const gpu_object::MeshBoundingBox &box,
-                               const CameraData &camera)
+bool should_object_be_rendered(const Transform &transform, const gpu_object::AABB &box, const CameraData &camera)
 {
     auto projection = camera.viewProjection * transform.getModelMatrix();
     auto bounding_box = box.vertices();

--- a/libgraphics/source/types/UniformBufferObject.cxx
+++ b/libgraphics/source/types/UniformBufferObject.cxx
@@ -1,6 +1,6 @@
 #include "pivot/graphics/types/UniformBufferObject.hxx"
+#include "pivot/graphics/types/AABB.hxx"
 #include "pivot/graphics/types/Material.hxx"
-#include "pivot/graphics/types/MeshBoundingBox.hxx"
 
 namespace pivot::graphics::gpu_object
 {
@@ -18,7 +18,7 @@ UniformBufferObject::UniformBufferObject(const RenderObject &obj, const AssetSto
     } else {
         materialIndex = assetStorage.getIndex<Material>(AssetStorage::missing_material_name);
     }
-    boundingBoxIndex = assetStorage.getIndex<MeshBoundingBox>(obj.meshID);
+    boundingBoxIndex = assetStorage.getIndex<AABB>(obj.meshID);
 }
 
 }    // namespace pivot::graphics::gpu_object

--- a/libgraphics/tests/bounding_box.cxx
+++ b/libgraphics/tests/bounding_box.cxx
@@ -1,4 +1,4 @@
-#include <pivot/graphics/types/MeshBoundingBox.hxx>
+#include <pivot/graphics/types/AABB.hxx>
 
 #include <catch2/catch_test_macros.hpp>
 #include <iostream>
@@ -8,7 +8,7 @@ using namespace pivot::graphics;
 
 TEST_CASE("bounding box calculation works", "[bounding_box]")
 {
-    MeshBoundingBox box({0, 0, 0});
+    AABB box({0, 0, 0});
 
     box.addPoint({1, -1, 0});
     REQUIRE(box.low == glm::vec3(0, -1, 0));
@@ -25,14 +25,14 @@ TEST_CASE("bounding box constructor is correct", "[bounding_box]")
             .pos = {1, -1, 0},
         },
     };
-    MeshBoundingBox box(vertex);
+    AABB box(vertex);
     REQUIRE(box.low == glm::vec3(0, -1, 0));
     REQUIRE(box.high == glm::vec3(1, 0, 0));
 }
 
 TEST_CASE("bounding box iteration", "[bounding_box]")
 {
-    MeshBoundingBox box({0, 0, 0}, {1, 1, 1});
+    AABB box({0, 0, 0}, {1, 1, 1});
     std::vector<glm::vec3> expectedVertices{
         {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {1, 1, 0}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1},
     };

--- a/libgraphics/tests/culling.cxx
+++ b/libgraphics/tests/culling.cxx
@@ -19,7 +19,7 @@ TEST_CASE("culling works", "[culling]")
     Transform transform_1{{0, 0, -1}, {0, 0, 0}, {1, 1, 1}};
     Transform transform_2{{0, 0, 1}, {0, 0, 0}, {1, 1, 1}};
     Transform transform_big{{0, 0, -1}, {0, 0, 0}, {10, 10, 10}};
-    MeshBoundingBox box{{-1, -1, -1}, {1, 1, 1}};
+    AABB box{{-1, -1, -1}, {1, 1, 1}};
 
     REQUIRE(pivot::graphics::culling::should_object_be_rendered(transform_1, box, camera));
     REQUIRE(!pivot::graphics::culling::should_object_be_rendered(transform_2, box, camera));


### PR DESCRIPTION
AABB = Axis Aligned Bounding Box

This is the correct name to avoid future confusions when non AABB will be added
