### PR TITLE
feat(AllocatedBuffer): allow buffer to have void type

### DIFF
--- a/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
+++ b/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
@@ -113,6 +113,7 @@ public:
     }
 
     template <BufferValid T>
+    /// Copy the vector into the buffer
     void copyBuffer(AllocatedBuffer<T> &buffer, const std::span<T> &data, std::size_t offset = 0)
     {
         return copyBuffer(buffer, data.data(), data.size_bytes(), offset);
@@ -124,6 +125,7 @@ public:
     {
         if (buffer) allocator.destroyBuffer(buffer.buffer, buffer.memory);
     }
+
     /// Destroy an image. Does not destroy its image view
     void destroyImage(AllocatedImage &image) { allocator.destroyImage(image.image, image.memory); }
 

--- a/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
+++ b/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
@@ -112,9 +112,7 @@ public:
         unmapMemory(buffer);
     }
 
-    template <typename T>
-    /// Copy the vector into the buffer
-    requires std::is_standard_layout_v<T>
+    template <BufferValid T>
     void copyBuffer(AllocatedBuffer<T> &buffer, const std::span<T> &data, std::size_t offset = 0)
     {
         return copyBuffer(buffer, data.data(), data.size_bytes(), offset);
@@ -128,6 +126,18 @@ public:
     }
     /// Destroy an image. Does not destroy its image view
     void destroyImage(AllocatedImage &image) { allocator.destroyImage(image.image, image.memory); }
+
+    template <BufferValid T>
+    /// Set allocation name
+    void setAllocationName(AllocatedBuffer<T> &buffer, const std::string &name) const
+    {
+        allocator.setAllocationName(buffer.memory, name.c_str());
+    }
+    /// @copydoc setAllocationName
+    void setAllocationName(AllocatedImage &image, const std::string &name) const
+    {
+        allocator.setAllocationName(image.memory, name.c_str());
+    }
 
     /// Print memory status to the logger
     void dumpStats();

--- a/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
+++ b/libgraphics/include/pivot/graphics/VulkanAllocator.hxx
@@ -110,7 +110,6 @@ public:
         auto *mapped = mapMemory<T>(buffer);
         std::memcpy(mapped + offset, data, data_size);
         unmapMemory(buffer);
-        buffer.size = (data_size + offset) / sizeof(T);
     }
 
     template <typename T>

--- a/libgraphics/include/pivot/graphics/types/AllocatedBuffer.hxx
+++ b/libgraphics/include/pivot/graphics/types/AllocatedBuffer.hxx
@@ -36,13 +36,15 @@ public:
 
     /// @brief get the byte size
     ///
-    /// When `T` is `void`, the size of buffer will be multiplied by `sizeof(T)`
-    auto getBytesSize() const noexcept requires(!std::is_same_v<T, void>) { return getSize() * sizeof(T); }
-    /// @copybrief getBytesSize
-    ///
-    /// When `T` is `void`, the size of buffer will be returned; as void does not have a size, we assume it is a buffer
-    /// of bytes
-    auto getBytesSize() const noexcept requires(std::is_same_v<T, void>) { return getSize(); }
+    /// When `T` is not `void`, the size of buffer will be multiplied by `sizeof(T)`
+    auto getBytesSize() const noexcept
+    {
+        if constexpr (std::is_same_v<T, void>) {
+            return getSize();
+        } else {
+            return getSize() * sizeof(T);
+        }
+    }
 
     /// return the info struct used when creating a descriptor set
     /// @see DescriptorBuilder::bindBuffer


### PR DESCRIPTION
In the future Transient Ressource System, I will need to store multiple templated version of the `AllocatedBuffer`.

This PR allow a void type buffer, **that is still valid to use**, but this allow to store AllocatedBuffer into a `std::vector<AllocatedBuffer<void>>` without having issue with the Template parameters.

Also, converting between `AllocatedBuffer<void>` to `AllocatedBuffer<T>` is allowed, but not the other way around.
